### PR TITLE
wmiexplorer - Update to v2.0.0.2

### DIFF
--- a/wmiexplorer/tools/chocolateyinstall.ps1
+++ b/wmiexplorer/tools/chocolateyinstall.ps1
@@ -8,8 +8,8 @@ Write-Host "WMI Explorer is going to be installed in '$installDir'"
 
 $packageArgs = @{
   packageName   = 'wmiexplorer'
-  url           = 'http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wmie&DownloadId=924042&FileTime=130588611924570000&Build=21063'
-  checksum      = 'F353C06DE8188A820FF7AC6FFD1CC296C44834EF4CF6BC248EF86D418D201B2E'
+  url           = 'https://github.com/vinaypamnani/wmie2/releases/download/v2.0.0.2/WmiExplorer_2.0.0.2.zip'
+  checksum      = '343695AE7BCD048DA51EBE0949BDF746F7C16F648746D9A4554B2CB888007851'
   checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
   unzipLocation = $installDir
 }

--- a/wmiexplorer/wmiexplorer.nuspec
+++ b/wmiexplorer/wmiexplorer.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wmiexplorer</id>
-    <version>2.0.0.0</version>
+    <version>2.0.0.2</version>
     <packageSourceUrl>https://github.com/Skatterbrainz/ChocolateyPackages/tree/master/wmiexplorer</packageSourceUrl>
     <owners>skatterbrainz</owners>
     <title>WMI Explorer (Install)</title>


### PR DESCRIPTION
A newer version of WMI Explorer was released a while back when the GitHub migration was completed:
https://github.com/vinaypamnani/wmie2/releases/tag/v2.0.0.2

Updating the package to point to the new version.