### PR TITLE
wmiexplorer - Add VERIFICATION.txt

### DIFF
--- a/wmiexplorer/tools/VERIFICATION.txt
+++ b/wmiexplorer/tools/VERIFICATION.txt
@@ -1,0 +1,14 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+ 
+1.  Download the zip:
+ 
+	x86/x64: http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wmie&DownloadId=924042&FileTime=130588611924570000&Build=21063
+ 
+2.  Use the Windows PowerShell cmdlet 'Get-FileHash'
+
+	Get-FileHash -Path '.\WMIExplorer_2.0.0.0.zip'
+ 
+    checksum: F353C06DE8188A820FF7AC6FFD1CC296C44834EF4CF6BC248EF86D418D201B2E

--- a/wmiexplorer/tools/VERIFICATION.txt
+++ b/wmiexplorer/tools/VERIFICATION.txt
@@ -5,10 +5,10 @@ in verifying that this package's contents are trustworthy.
  
 1.  Download the zip:
  
-	x86/x64: http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=wmie&DownloadId=924042&FileTime=130588611924570000&Build=21063
+	x86/x64: https://github.com/vinaypamnani/wmie2/releases/download/v2.0.0.2/WmiExplorer_2.0.0.2.zip
  
 2.  Use the Windows PowerShell cmdlet 'Get-FileHash'
 
-	Get-FileHash -Path '.\WMIExplorer_2.0.0.0.zip'
+	Get-FileHash -Path '.\WmiExplorer_2.0.0.2.zip'
  
-    checksum: F353C06DE8188A820FF7AC6FFD1CC296C44834EF4CF6BC248EF86D418D201B2E
+    checksum: 343695AE7BCD048DA51EBE0949BDF746F7C16F648746D9A4554B2CB888007851


### PR DESCRIPTION
The repository is currently missing the `VERIFICATION.txt` file that is normally distributed with the package. Adding this file for completion's sake.

I've also included in a separate commit an update that should've gone with #3.